### PR TITLE
Configuring install location

### DIFF
--- a/cjklib/dictionary/install.py
+++ b/cjklib/dictionary/install.py
@@ -343,7 +343,7 @@ class DictionaryInstaller(object):
         projectName='cjklib'):
 
         configuration = dbconnector.getDefaultConfiguration()
-        if not configuration['sqlalchemy.url'].startswith('sqlite://'):
+        if configuration['sqlalchemy.url'].startswith('sqlite://'):
             # only know how to connect to this database
             return configuration['sqlalchemy.url']
 


### PR DESCRIPTION
When trying to set up cjklib in a development environment I want to control where the databases download to.

So I have the config file in $HOME/.cjklib.conf.

I set

```
[Connection]
url = sqlite:////Users/tony/.cjklib/cjklib.db
```

I would expect `cjklib.dictionary.install` to install cjklib.db to my user directory. However, it detects I'm on OSX (darwin) and attempts to install it to the system's Application Support.

The installer will use `DictonaryInstaller.getDefaultDatabaseUrl()`. As I would expect, it detects configuration['sqlalchemy.url'] in my config file, and also will default to download it to the cjklib dir itself (`cjklib/cjklib/cjklib.db`).

My fix allowed me to move forward configuring a local environment and installed the db to the correct location.
